### PR TITLE
Remove print logging

### DIFF
--- a/pytest_custom_exit_code.py
+++ b/pytest_custom_exit_code.py
@@ -15,7 +15,6 @@ def pytest_addoption(parser):
 
 @pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session, exitstatus):
-    print('In  plugin session finish')
     if session.config.getoption('--suppress-no-test-exit-code'):
         from _pytest.main import EXIT_NOTESTSCOLLECTED, EXIT_OK
         if exitstatus == EXIT_NOTESTSCOLLECTED:


### PR DESCRIPTION
This plugin is exactly what I need, but I'd rather it not print output during my test run.