### PR TITLE
ExitCode is part of the public API

### DIFF
--- a/pytest_custom_exit_code.py
+++ b/pytest_custom_exit_code.py
@@ -23,7 +23,7 @@ def pytest_sessionfinish(session, exitstatus):
             ok = EXIT_OK
         except ImportError:
             # From pytest 5 on the values are inside an enum
-            from _pytest.main import ExitCode
+            from pytest import ExitCode
             no_tests_collected = ExitCode.NO_TESTS_COLLECTED
             ok = ExitCode.OK
 


### PR DESCRIPTION
Hi,

Just discovered this through https://github.com/pytest-dev/pytest/issues/5689, nice work!

Changing the import to no longer use the internal name, given that `ExitCode` is now public API.