### PR TITLE
Add support for TESTS_FAILED exit code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,8 @@ Usage
 
     pytest --suppress-no-test-exit-code
 
+    pytest --suppress-tests-failed-exit-code
+
 Contributing
 ------------
 Contributions are very welcome. Tests can be run with `tox`_, please ensure

--- a/pytest_custom_exit_code.py
+++ b/pytest_custom_exit_code.py
@@ -11,21 +11,33 @@ def pytest_addoption(parser):
         default=False,
         help='Suppress the "no tests collected" exit code.'
     )
+    group.addoption(
+        '--suppress-tests-failed-exit-code',
+        action='store_true',
+        default=False,
+        help='Suppress the "some tests failed" exit code.'
+    )
 
 
 @pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session, exitstatus):
-    if session.config.getoption('--suppress-no-test-exit-code'):
-        try:
-            # Before pytest 5 the values were contants
-            from _pytest.main import EXIT_NOTESTSCOLLECTED, EXIT_OK
-            no_tests_collected = EXIT_NOTESTSCOLLECTED
-            ok = EXIT_OK
-        except ImportError:
-            # From pytest 5 on the values are inside an enum
-            from pytest import ExitCode
-            no_tests_collected = ExitCode.NO_TESTS_COLLECTED
-            ok = ExitCode.OK
+    try:
+        # Before pytest 5 the values were contants
+        from _pytest.main import EXIT_NOTESTSCOLLECTED, EXIT_TESTSFAILED, EXIT_OK
+        no_tests_collected = EXIT_NOTESTSCOLLECTED
+        tests_failed = EXIT_TESTSFAILED
+        ok = EXIT_OK
+    except ImportError:
+        # From pytest 5 on the values are inside an enum
+        from pytest import ExitCode
+        no_tests_collected = ExitCode.NO_TESTS_COLLECTED
+        tests_failed = ExitCode.TESTS_FAILED
+        ok = ExitCode.OK
 
+    if session.config.getoption('--suppress-no-test-exit-code'):
         if exitstatus == no_tests_collected:
+            session.exitstatus = ok
+
+    if session.config.getoption('--suppress-tests-failed-exit-code'):
+        if exitstatus == tests_failed:
             session.exitstatus = ok

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name='pytest-custom_exit_code',
-    version='0.2.1',
+    version='0.3.0',
     author='Yash Todi',
     author_email='yashtodi94@gmail.com',
     maintainer='Yash Todi',

--- a/tests/test_custom_exit_code.py
+++ b/tests/test_custom_exit_code.py
@@ -15,3 +15,23 @@ def test_bar_fixture(testdir):
 
     # make sure that that we get a '0' exit code for the testsuite
     assert result.ret == 0
+
+
+def test_tests_failed(testdir):
+    """Make sure that pytest accepts our fixture."""
+
+    # create a temporary pytest test module
+    testdir.makepyfile("""
+        import pytest
+        def test_fail():
+            assert 1 == 2
+        """)
+
+    # run pytest with the following cmd args
+    result = testdir.runpytest(
+        '--suppress-tests-failed-exit-code',
+        '-v'
+    )
+
+    # make sure that that we get a '0' exit code for the testsuite
+    assert result.ret == 0


### PR DESCRIPTION
Add support to suppress the TESTS_FAILED exit code.

Tested in Python 3.6 with pytest 4.6.5 and 5.0.1.