### PR TITLE
Fix PyPi project link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ If you encounter any problems, please `file an issue`_ along with a detailed des
 .. _`pytest`: https://github.com/pytest-dev/pytest
 .. _`tox`: https://tox.readthedocs.io/en/latest/
 .. _`pip`: https://pypi.org/project/pip/
-.. _`PyPI`: https://pypi.org/project
+.. _`PyPI`: https://pypi.org/project/pytest-custom-exit-code/
 
 
 Acknowledegements


### PR DESCRIPTION
The link currently used is dead.  This switches the dead link to be a link to the project page on PyPi.